### PR TITLE
Add support for including optional attendees in meeting times

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -66,7 +66,7 @@ public final class FindMeetingQuery {
       availableTimes.add(TimeRange.fromStartEnd(startPointer, TimeRange.END_OF_DAY, true));
     }
 
-    Collection<TimeRange> optionalAvailableTimes = new ArrayList<>();
+    Collection<TimeRange> optionalTimesRequest = new ArrayList<>();
     if (request.getOptionalAttendees().size() > 0) {
       // get available times for optional attendees
       MeetingRequest requestOptionalTimes = new MeetingRequest(request.getOptionalAttendees(), request.getDuration());
@@ -80,25 +80,27 @@ public final class FindMeetingQuery {
           TimeRange currentAvailableTime = availableTimes.get(i);
 
           if (optionalTime.contains(currentAvailableTime)) {
-            optionalAvailableTimes.add(currentAvailableTime);
+            optionalTimesRequest.add(currentAvailableTime);
           } else if (currentAvailableTime.contains(optionalTime)) {
-            optionalAvailableTimes.add(optionalTime);
+            optionalTimesRequest.add(optionalTime);
             break; // move on to next optional time
           } else if (optionalTime.overlaps(currentAvailableTime)) {
             if (optionalTime.start() - currentAvailableTime.end() >= request.getDuration()) {
-              optionalAvailableTimes.add(TimeRange.fromStartEnd(optionalTime.start(), currentAvailableTime.end(), false));
+              optionalTimesRequest.add(TimeRange.fromStartEnd(optionalTime.start(), currentAvailableTime.end(), false));
             } else if (currentAvailableTime.start() - optionalTime.end() >= request.getDuration()) {
-              optionalAvailableTimes.add(TimeRange.fromStartEnd(currentAvailableTime.start(), optionalTime.end(), false));
+              optionalTimesRequest.add(TimeRange.fromStartEnd(currentAvailableTime.start(), optionalTime.end(), false));
               break;
             }
+          } else if (optionalTime.start() > currentAvailableTime.start()) {
+            break;
           }
         }
       }
     }
     
     // check which list of timeranges is to be returned
-    if (optionalAvailableTimes.size() > 0 || (request.getAttendees().size() == 0 && request.getOptionalAttendees().size() > 0)) {
-      return optionalAvailableTimes;
+    if (optionalTimesRequest.size() > 0 || (request.getAttendees().size() == 0 && request.getOptionalAttendees().size() > 0)) {
+      return optionalTimesRequest;
     } else {
       return availableTimes;
     }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -61,8 +61,8 @@ public final class FindMeetingQuery {
       }
     }
 
-    // check END_OF_DAY time slot
-    if (TimeRange.END_OF_DAY - startPointer >= request.getDuration()) {
+    // check END_OF_DAY time slot, need to include 23:59 so + 1
+    if (TimeRange.END_OF_DAY - startPointer + 1 >= request.getDuration()) {
       availableTimes.add(TimeRange.fromStartEnd(startPointer, TimeRange.END_OF_DAY, true));
     }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -46,6 +46,9 @@ public final class MeetingRequest {
    * Returns a read-only copy of the people who are optional to attend this meeting.
    */
   public Collection<String> getOptionalAttendees() {
+    if (optional_attendees == null) {
+      return Collections.unmodifiableCollection(new HashSet<>());
+    }
     return Collections.unmodifiableCollection(optional_attendees);
   }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -47,7 +47,7 @@ public final class MeetingRequest {
    */
   public Collection<String> getOptionalAttendees() {
     if (optional_attendees == null) {
-      return Collections.unmodifiableCollection(new HashSet<>());
+      return Collections.emptySet();
     }
     return Collections.unmodifiableCollection(optional_attendees);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -463,5 +463,24 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void ExistingEventEndAt1130PM() {
+    // Have one mandatory attendee with an event that ends near end of day
+    //
+    // Events  : |------A---------|
+    // Day     : |---------------------|
+    // Options :                  
+    Collection<Event> events = Arrays.asList(
+      new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_1130PM, false),
+        Arrays.asList(PERSON_A)));
+    
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartDuration(TIME_1130PM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
 }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -43,6 +43,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
+  private static final int TIME_1130PM = TimeRange.getTimeInMinutes(23, 30);
 
   private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
@@ -404,6 +405,61 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void wholeDayEventBothAttend() {
+    // Have one mandatory attendee and one optional attendee with no events
+    //
+    // Events  : 
+    // Day     : |---------------------|
+    // Options : |---------------------|
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(NO_EVENTS, request);
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void PersonAHasWholeDayEvent() {
+    // Have one mandatory attendee and one optional attendee with no events
+    //
+    // Events  : |--------A------------|
+    // Day     : |---------------------|
+    // Options : 
+    Collection<Event> events = Arrays.asList(
+      new Event("Event 1", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_A)));
+    
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void EventEndsAfterEndOfDay() {
+    // Have one mandatory attendee with an event that ends after the end of day
+    //
+    // Events  :                |--A--------|
+    // Day     : |---------------------|
+    // Options : 
+    Collection<Event> events = Arrays.asList(
+      new Event("Event 1", TimeRange.fromStartDuration(TIME_1130PM, DURATION_90_MINUTES),
+        Arrays.asList(PERSON_A)));
+    
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_1130PM, false));
 
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
Added new basic functionality to query function so that if one or more time slots exist in which both optional and mandatory attendees can attend those time slots will be returned. Otherwise, return the time slots that fit only the mandatory attendees. I also had to add a check for null in getOptionalAttendees because using the already written code that was given gives an error for null pointer exception when running the web application.